### PR TITLE
several minor ui edits - fixes #7

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@
 Allows users to log in, set up a profile, bookmark and save their favorite walks, like/unlike their favorite walks, and upload their own walks. Imagined during the pandemic and built for anyone anywhere that wants to get away to the vast and beautiful outdoors but isn't able to at the moment. A chance to relax, unwind, reset, and recharge. 
 
 ### Visit the deployed site:
-https://parkside-virtual-walks-app.herokuapp.com/ <br>
+https://parkside-virtual-walks-app.herokuapp.com/<br>
 
-### Demo User:
+### Demo user:
 email: tester1234@gmail.com<br>
 password: tester1234
 

--- a/views/feed.ejs
+++ b/views/feed.ejs
@@ -6,7 +6,7 @@
     <% for(var i=0; i<posts.length; i++) {%>
     <div class="col">
       <div class="card bg-dark-1 text-white h-100">
-        <img src="<%= posts[i].image%>" class="card-img-top" alt="...">
+        <a href="/post/<%= posts[i]._id%>"><img src="<%= posts[i].image%>" class="card-img-top" alt="..."></a>
         <div class="card-body">
           <h5 class="card-title"><%= posts[i].title %></h5>
           <p class="card-text"><small class="text-muted accent-1">YouTube Guide: <%= posts[i].youTubeUser %></small></p>

--- a/views/get-started.ejs
+++ b/views/get-started.ejs
@@ -12,7 +12,7 @@
         <p class="lead">Welcome to your walks. We've curated for you the highest quality collection of relaxing and immersive virtual walks in US National Parks created by the most accomplished YouTube guides and influencers. Here you are invited to relax, unwind, and experience the splendor of some of the US's most mesmerizing landscapes.</p>
         <div class="d-grid gap-2 d-md-flex justify-content-md-start">
           <a href="/signup" type="button" class="btn btn-primary rounded-pill shadow-none btn-lg cap-btn">
-            Explore
+            Explore Now
           </a>
         </div>
       </div>

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Otherworldly Event Booker</title>
+    <title>Parkside Paradise Virtual Walks</title>
     <link
       rel="icon"
       type="image/png"

--- a/views/my-walks.ejs
+++ b/views/my-walks.ejs
@@ -6,7 +6,7 @@
     <% for(var i=0; i<posts.length; i++) {%>
     <div class="col">
       <div class="card bg-dark-1 text-white h-100">
-        <img src="<%= posts[i].image%>" class="card-img-top" alt="...">
+        <a href="/post/<%= posts[i]._id%>"><img src="<%= posts[i].image%>" class="card-img-top" alt="..."></a>
         <div class="card-body">
           <h5 class="card-title"><%= posts[i].title %></h5>
           <p class="card-text"><%= posts[i].subtitle %></p>

--- a/views/partials/header-logged-in.ejs
+++ b/views/partials/header-logged-in.ejs
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Parkside Virtual Walks</title>
+    <title>Parkside Paradise Virtual Walks</title>
     <link
       rel="icon"
       type="image/png"

--- a/views/partials/header.ejs
+++ b/views/partials/header.ejs
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Parkside Virtual Walks</title>
+    <title>Parkside Paradise Virtual Walks</title>
     <link
       rel="icon"
       type="image/png"

--- a/views/saved-walks.ejs
+++ b/views/saved-walks.ejs
@@ -8,7 +8,7 @@
       <%if(posts[i].bookmarks.includes(user.id)) {%>
     <div class="col">
       <div class="card bg-dark-1 text-white h-100">
-        <img src="<%= posts[i].image%>" class="card-img-top" alt="...">
+        <a href="/post/<%= posts[i]._id%>"><img src="<%= posts[i].image%>" class="card-img-top" alt="..."></a>
        
         <div class="card-body">
           <h5 class="card-title"><%= posts[i].title %></h5>


### PR DESCRIPTION
Fixed 3 of 4 minor ui fixes across the site:

- [X] change explore button to explore now on get-started
- [X]  add link to images on feed, saved-walks, my-walks pages to view details button
- [X]  Demo User in readme should be a small u for consistency

_**[ ]  possibly remove view details button and move the like feature on feed posts based on new format without button**_
Was not implemented as upon testing I prefer the buttons, at least for now, may revisit this issue later

Also made several other minor changes including editing titles of pages.