### PR TITLE
Implement open videos in full screen and autoplay - fixes #9

### DIFF
--- a/controllers/posts.js
+++ b/controllers/posts.js
@@ -80,6 +80,7 @@ module.exports = {
         speaking: req.body.speaking,
         mainTerrain: req.body.mainTerrain,
         videoUrl: req.body.videoUrl,
+        videoUrlFullScreen: req.body.videoUrl.replace('watch?v=', 'embed/') + '?autoplay=1',
         youTubeUser: req.body.youTubeUser,
         likes: 0,
         user: req.user.id,

--- a/models/Post.js
+++ b/models/Post.js
@@ -25,6 +25,10 @@ const PostSchema = new mongoose.Schema({
     type: String,
     require: true,
   },
+  videoUrlFullScreen: {
+    type: String,
+    require: true,
+  },
   youTubeUser: {
     type: String,
     require: true,

--- a/views/post.ejs
+++ b/views/post.ejs
@@ -52,7 +52,7 @@
 
         <hr class="style1">
         <div class="d-grid gap-2 d-md-flex justify-content-md-start">
-          <a href="<%= post.videoUrl %>" target="_blank" type="button" class="btn btn-primary rounded-pill shadow-none btn-lg">
+          <a href="<%= post.videoUrlFullScreen %>" target="_blank" type="button" class="btn btn-primary rounded-pill shadow-none btn-lg">
             Watch Now
           </a>
           


### PR DESCRIPTION
- [X] Created new property and added to the post model and the post controller, videoUrlFullScreen. Leveraged existing property of original videoUrl to create a modified url for videoUrlFullScreen 
- [X] Kept videoUrl property to preserve original user entered url in case I want to revert back from full screen, or alter original url for other features.
- [X] Added and populated new videoUrlFullScreen property to MongoDB for all pre-existing posts
- [X] Tested that both newly created post videos open in full screen and autoplay, as well as pre-existing post videos