### PR TITLE
Get started layout edits, standardized spacing across views - fixes #16

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -114,7 +114,7 @@ footer a:hover {
     color: rgb(49, 166, 49);
 }
 
-.card-container{
+.main{
   margin-top: 10rem;  
 }
 .bg-dark-1 {

--- a/views/feed.ejs
+++ b/views/feed.ejs
@@ -1,9 +1,9 @@
 <%- include('partials/header-logged-in') -%>
 
-  <div id="container-wide" class="container card-container">
-    <h1>Explore Walks</h1>
+<div id="container-wide" class="container card-container main">
+  <h1>Explore Walks</h1>
   <div class="row row-cols-1 row-cols-md-3 g-4">
-    <% for(var i=0; i<posts.length; i++) {%>
+    <% for(var i=0; i<posts.length; i++) { %>
     <div class="col">
       <div class="card bg-dark-1 text-white h-100">
         <a href="/post/<%= posts[i]._id%>"><img src="<%= posts[i].image%>" class="card-img-top" alt="..."></a>

--- a/views/get-started.ejs
+++ b/views/get-started.ejs
@@ -2,14 +2,14 @@
 
   <!-- Remove id, width issue related to an extra outside div possibly, check and remove but don't lose row-reverse on first and last container-->
 
-  <div id="bg-image-index" class="container col-xxl-8 px-1 py-4 card-container">
+  <div id="bg-image-index" class="container px-1 py-4 card-container main">
     <div class="row flex-lg-row-reverse align-items-center g-5 py-4">
       <div class="col-10 col-sm-8 col-lg-6">
         <img src="/imgs/sequoia2.jpg" class="d-block mx-lg-auto img-fluid" alt="Bootstrap Themes" width="600" height="400" loading="lazy">
       </div>
       <div class="col-lg-6">
         <h1 class="display-5 fw-bold lh-1 mb-3">Immersive <span class="accent-1">Walks</span></h1>
-        <p class="lead">Welcome to your walks. We've curated for you the highest quality collection of relaxing and immersive virtual walks in US National Parks created by the most accomplished YouTube guides and influencers. Here you are invited to relax, unwind, and experience the splendor of some of the US's most mesmerizing landscapes.</p>
+        <p class="lead">Welcome to Parkside Paradise Virtual Walks. We've curated for you the highest quality collection of relaxing and immersive virtual walks in US National Parks created by the most accomplished YouTube guides and influencers. Here you are invited to relax, unwind, and experience the splendor of some of the US's most mesmerizing landscapes.</p>
         <div class="d-grid gap-2 d-md-flex justify-content-md-start">
           <a href="/signup" type="button" class="btn btn-primary rounded-pill shadow-none btn-lg cap-btn">
             Explore Now
@@ -18,7 +18,7 @@
       </div>
     </div>
   </div>
-  <div id="bg-image-index" class="container col-xxl-8 px-1 py-4 card-container">
+  <div id="bg-image-index" class="container px-1 py-4 card-container">
     <div class="row flex-lg align-items-center g-5 py-4">
       <div class="col-10 col-sm-8 col-lg-6">
         <img src="/imgs/pier.jpg" class="d-block mx-lg-auto img-fluid" alt="Bootstrap Themes" width="600" height="400" loading="lazy">
@@ -37,7 +37,7 @@
     </div>
   </div>
 
-  <div id="bg-image-index" class="container col-xxl-8 px-1 py-4 card-container">
+  <div id="bg-image-index" class="container px-1 py-4 card-container">
     <div class="row flex-lg-row-reverse align-items-center g-5 py-4">
       <div class="col-10 col-sm-8 col-lg-6">
         <img src="/imgs/tree.jpg" class="d-block mx-lg-auto img-fluid" alt="Bootstrap Themes" width="600" height="400" loading="lazy">

--- a/views/login.ejs
+++ b/views/login.ejs
@@ -1,6 +1,6 @@
 <%- include('partials/header') -%>
 
-<main class="container card-container">
+<main class="container card-container main">
   <div class="row justify-content-center">
     <section class="col-6 mt-5">
       <h1>Log in with email</h1>

--- a/views/my-walks.ejs
+++ b/views/my-walks.ejs
@@ -1,6 +1,6 @@
 <%- include('partials/header-logged-in') -%>
 
-<div class="container card-container">
+<div class="container card-container main">
   <h1>My Uploaded Walks</h1>
   <div class="row row-cols-1 row-cols-md-3 g-4">
     <% for(var i=0; i<posts.length; i++) {%>

--- a/views/post.ejs
+++ b/views/post.ejs
@@ -1,5 +1,5 @@
 <%- include('partials/header-logged-in') -%>
-<div class="container card-container">
+<div class="container card-container main">
 
     <div class="row">
       <h1 class="display-4"><%= post.title %></h1>

--- a/views/profile.ejs
+++ b/views/profile.ejs
@@ -1,6 +1,6 @@
 <%- include('partials/header-logged-in') -%>
 
-<div class="container card-container">
+<div class="container card-container main">
   <h1>Add a Walk</h1>
   <p>Thanks for contributing to our platform <span class="accent-1"><%= user.userName %></span>!</p>
   <!-- <span>Email: <%= user.email %></span> -->

--- a/views/saved-walks.ejs
+++ b/views/saved-walks.ejs
@@ -1,6 +1,6 @@
 <%- include('partials/header-logged-in') -%>
 
-<div class="container card-container">
+<div class="container card-container main">
   <h1>My Saved Walks</h1>
   <% console.log(posts[0]) %> 
   <div class="row row-cols-1 row-cols-md-3 g-4">

--- a/views/signup.ejs
+++ b/views/signup.ejs
@@ -1,6 +1,6 @@
 <%- include('partials/header') -%>
 
-<main class="container card-container">
+<main class="container card-container main">
   <div class="row justify-content-center">
       <section class="col-6 mt-5">
         <h1>Sign up with email</h1>


### PR DESCRIPTION
- [X] Fixed width of containers on get-started page to page size to match the standard width across the site (issue was with responsive container at xxl breakpoint)
- [X] Reduced spacing of components in relation to each other on get-started page to be consistent with spacing site wide
- [X] Added class "main" to all first card-containers across views to standardize spacing from header. Changed css rule to remove the rule from class card-container and add the rule to class main to affect only targeted first containers. 
- [ ] While redesigning, determine if margins should be expanded on this page as well as site wide pages to fuller width of page _**(Breaking this task out into a separate issue)**_