### PR TITLE
Display logo correctly on post page - fixes #26

### DIFF
--- a/views/partials/header-logged-in.ejs
+++ b/views/partials/header-logged-in.ejs
@@ -37,8 +37,8 @@
         style="background-color: rgb(49, 166, 49)">
         <div class="container">
           <a class="navbar-brand" href="/feed">
-            <img src="imgs/parkside-logo-110x110.png" 
-              srcset="imgs/parkside-logo-200x200.png 2x, imgs/parkside-logo-110x110.png 1x" 
+            <img src="/imgs/parkside-logo-110x110.png" 
+              srcset="/imgs/parkside-logo-200x200.png 2x, /imgs/parkside-logo-110x110.png 1x" 
               alt="Parkside Logo"
               width="100" height="100"
             >


### PR DESCRIPTION
**Issue:**
The Parkside logo was not rendering on the /post/:id page.

**Root Cause:**
The relative URL was causing issues on nested routes, leading the browser to look for the image asset in the wrong location.

**Fix:**
Updated the image paths to use absolute URLs. This ensures that no matter where the partial is included, it always references the image from the root of the site.

**Changes Made:**
Updated the src attribute to use an absolute path: /imgs/parkside-logo-110x110.png.
Updated the srcset attribute to use absolute paths for both image resolutions.
This update was implemented in 3 places total.